### PR TITLE
add firehose block downloader and upgrader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,4 +166,4 @@ replace github.com/ShinyTrinkets/overseer => github.com/streamingfast/overseer v
 
 replace github.com/EOS-Nation/firehose-antelope/types => ./types
 
-replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765
+replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124112226-e7ddeb7afaa3

--- a/go.mod
+++ b/go.mod
@@ -163,3 +163,5 @@ require (
 )
 
 replace github.com/ShinyTrinkets/overseer => github.com/streamingfast/overseer v0.2.1-0.20210326144022-ee491780e3ef
+
+replace github.com/EOS-Nation/firehose-antelope/types => ./types

--- a/go.mod
+++ b/go.mod
@@ -165,3 +165,5 @@ require (
 replace github.com/ShinyTrinkets/overseer => github.com/streamingfast/overseer v0.2.1-0.20210326144022-ee491780e3ef
 
 replace github.com/EOS-Nation/firehose-antelope/types => ./types
+
+replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c

--- a/go.mod
+++ b/go.mod
@@ -166,4 +166,4 @@ replace github.com/ShinyTrinkets/overseer => github.com/streamingfast/overseer v
 
 replace github.com/EOS-Nation/firehose-antelope/types => ./types
 
-replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c
+replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24

--- a/go.mod
+++ b/go.mod
@@ -166,4 +166,4 @@ replace github.com/ShinyTrinkets/overseer => github.com/streamingfast/overseer v
 
 replace github.com/EOS-Nation/firehose-antelope/types => ./types
 
-replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24
+replace github.com/streamingfast/sf-tools => github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c h1:nqzhBU3X73y
 github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24 h1:7ID6f39KQRTVgR1GDqkrDkgbtm/5vC53asotUaYYnuQ=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765 h1:ZGAlBwcappxZ3Xih9iNnyYNtz1cQyZqe8R+PltbXezo=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3 h1:fiyErF/p5fz79DvMCca9ayvYiWYsFP1oJbskt9fjo8I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 h1:TOxk7n3PE2OkdNMgrXDtDr3ju4pIvwhY515tCoH0CpE=

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/EOS-Nation/firehose-antelope/types v0.0.0-20220929143722-79603ee4aaa8
 github.com/EOS-Nation/firehose-antelope/types v0.0.0-20220929143722-79603ee4aaa8/go.mod h1:D/uBTHauhuxE22RRkOtNTQXBO2CpWU8sOrS2d9sFvCk=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c h1:nqzhBU3X73yvLMOEls0iWS+w/mkBQDIxjnzQIOaEN/4=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24 h1:7ID6f39KQRTVgR1GDqkrDkgbtm/5vC53asotUaYYnuQ=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3 h1:fiyErF/p5fz79DvMCca9ayvYiWYsFP1oJbskt9fjo8I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 h1:TOxk7n3PE2OkdNMgrXDtDr3ju4pIvwhY515tCoH0CpE=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/EOS-Nation/firehose-antelope/types v0.0.0-20220929143722-79603ee4aaa8 h1:qWYodJBNSLw81kbngGSxvsGOwZmtn2XdYX5j8K8s0/k=
 github.com/EOS-Nation/firehose-antelope/types v0.0.0-20220929143722-79603ee4aaa8/go.mod h1:D/uBTHauhuxE22RRkOtNTQXBO2CpWU8sOrS2d9sFvCk=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c h1:nqzhBU3X73yvLMOEls0iWS+w/mkBQDIxjnzQIOaEN/4=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124085003-eb76d810cb6c/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3 h1:fiyErF/p5fz79DvMCca9ayvYiWYsFP1oJbskt9fjo8I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 h1:TOxk7n3PE2OkdNMgrXDtDr3ju4pIvwhY515tCoH0CpE=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24 h1:7ID6f39KQRT
 github.com/EOS-Nation/sf-tools v0.0.0-20221124103823-34bbeae74f24/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765 h1:ZGAlBwcappxZ3Xih9iNnyYNtz1cQyZqe8R+PltbXezo=
 github.com/EOS-Nation/sf-tools v0.0.0-20221124110623-b15f0b7d7765/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124112226-e7ddeb7afaa3 h1:1rWNvdSa3uSg8rif3mV3qIEGD+uQz878UhE6IsfPVi0=
+github.com/EOS-Nation/sf-tools v0.0.0-20221124112226-e7ddeb7afaa3/go.mod h1:NTrKtcP7QPEMEu/rRbThGqwNb3dI7LHLmE5Kn00UyGU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3 h1:fiyErF/p5fz79DvMCca9ayvYiWYsFP1oJbskt9fjo8I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 h1:TOxk7n3PE2OkdNMgrXDtDr3ju4pIvwhY515tCoH0CpE=

--- a/tools/cmd.go
+++ b/tools/cmd.go
@@ -15,11 +15,13 @@
 package tools
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/cli"
 )
 
-var Cmd = &cobra.Command{Use: "tools", Short: "Developer tools related to sfeth"}
+var Cmd = &cobra.Command{Use: "tools", Short: "Developer tools related to fireantelope"}
 
 var Example = func(in string) string {
 	return string(cli.Example(in))
@@ -27,4 +29,33 @@ var Example = func(in string) string {
 
 var ExamplePrefixed = func(prefix, in string) string {
 	return string(cli.ExamplePrefixed(prefix, in))
+}
+
+func mustGetString(cmd *cobra.Command, flagName string) string {
+	val, err := cmd.Flags().GetString(flagName)
+	if err != nil {
+		panic(fmt.Sprintf("flags: couldn't find flag %q", flagName))
+	}
+	return val
+}
+func mustGetInt64(cmd *cobra.Command, flagName string) int64 {
+	val, err := cmd.Flags().GetInt64(flagName)
+	if err != nil {
+		panic(fmt.Sprintf("flags: couldn't find flag %q", flagName))
+	}
+	return val
+}
+func mustGetUint64(cmd *cobra.Command, flagName string) uint64 {
+	val, err := cmd.Flags().GetUint64(flagName)
+	if err != nil {
+		panic(fmt.Sprintf("flags: couldn't find flag %q", flagName))
+	}
+	return val
+}
+func mustGetBool(cmd *cobra.Command, flagName string) bool {
+	val, err := cmd.Flags().GetBool(flagName)
+	if err != nil {
+		panic(fmt.Sprintf("flags: couldn't find flag %q", flagName))
+	}
+	return val
 }

--- a/tools/download-blocks-from-firehose.go
+++ b/tools/download-blocks-from-firehose.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
 	"os"
 	"strconv"
 
@@ -51,8 +52,9 @@ func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
 	apiToken := os.Getenv(apiTokenEnvVar)
 
 	val, err := cmd.Flags().GetUint32("block-version")
-	if err == nil {
+	if err == nil && val > 0 {
 		blockVersion = val
+		zlog.Info("updating block version", zap.Uint32("block_version", blockVersion))
 	}
 
 	plaintext := mustGetBool(cmd, "plaintext")

--- a/tools/download-blocks-from-firehose.go
+++ b/tools/download-blocks-from-firehose.go
@@ -70,6 +70,7 @@ func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
 		start,
 		stop,
 		destFolder,
+		true,
 		decodeAndUpdateBlock,
 		fixerFunc,
 		zlog,

--- a/tools/download-blocks-from-firehose.go
+++ b/tools/download-blocks-from-firehose.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/firehose-ethereum/types"
+	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
+	sftools "github.com/streamingfast/sf-tools"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func init() {
+	Cmd.AddCommand(DownloadFromFirehoseCmd)
+	DownloadFromFirehoseCmd.Flags().StringP("api-token-env-var", "a", "FIREHOSE_API_TOKEN", "Look for a JWT in this environment variable to authenticate against endpoint")
+	DownloadFromFirehoseCmd.Flags().BoolP("plaintext", "p", false, "Use plaintext connection to firehose")
+	DownloadFromFirehoseCmd.Flags().BoolP("insecure", "k", false, "Skip SSL certificate validation when connecting to firehose")
+	DownloadFromFirehoseCmd.Flags().Bool("fix-ordinals", false, "Decode the eth blocks to fix the ordinals in the receipt logs")
+}
+
+var DownloadFromFirehoseCmd = &cobra.Command{
+	Use:     "download-from-firehose <endpoint> <start> <stop> <destination>",
+	Short:   "download blocks from firehose and save them to merged-blocks",
+	Args:    cobra.ExactArgs(4),
+	RunE:    downloadFromFirehoseE,
+	Example: "fireeth tools download-from-firehose api.streamingfast.io 1000 2000 ./outputdir",
+}
+
+func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	endpoint := args[0]
+	start, err := strconv.ParseUint(args[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("parsing start block num: %w", err)
+	}
+	stop, err := strconv.ParseUint(args[2], 10, 64)
+	if err != nil {
+		return fmt.Errorf("parsing stop block num: %w", err)
+	}
+	destFolder := args[3]
+
+	apiTokenEnvVar := mustGetString(cmd, "api-token-env-var")
+	apiToken := os.Getenv(apiTokenEnvVar)
+
+	plaintext := mustGetBool(cmd, "plaintext")
+	insecure := mustGetBool(cmd, "insecure")
+	var fixerFunc func(*bstream.Block) (*bstream.Block, error)
+	if mustGetBool(cmd, "fix-ordinals") {
+		fixerFunc = func(in *bstream.Block) (*bstream.Block, error) {
+			block := in.ToProtocol().(*pbeth.Block)
+			block.NormalizeInPlace()
+			return types.BlockFromProto(block, in.LibNum)
+		}
+	}
+
+	return sftools.DownloadFirehoseBlocks(
+		ctx,
+		endpoint,
+		apiToken,
+		insecure,
+		plaintext,
+		start,
+		stop,
+		destFolder,
+		decodeAnyPB,
+		fixerFunc,
+		zlog,
+	)
+}
+
+func decodeAnyPB(in *anypb.Any) (*bstream.Block, error) {
+	block := &pbeth.Block{}
+	if err := anypb.UnmarshalTo(in, block, proto.UnmarshalOptions{}); err != nil {
+		return nil, fmt.Errorf("unmarshal anypb: %w", err)
+	}
+
+	// We are downloading only final blocks from the Firehose connection which means the LIB for them
+	// can be set to themself (althought we use `- 1` to ensure problem would occur if codde don't like
+	// `LIBNum == self.BlockNum`).
+	return types.BlockFromProto(block, block.Number-1)
+}

--- a/tools/download-blocks-from-firehose.go
+++ b/tools/download-blocks-from-firehose.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/EOS-Nation/firehose-antelope/types"
+	pbantelope "github.com/EOS-Nation/firehose-antelope/types/pb/sf/antelope/type/v1"
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/bstream"
-	"github.com/streamingfast/firehose-ethereum/types"
-	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 	sftools "github.com/streamingfast/sf-tools"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -20,7 +20,7 @@ func init() {
 	DownloadFromFirehoseCmd.Flags().StringP("api-token-env-var", "a", "FIREHOSE_API_TOKEN", "Look for a JWT in this environment variable to authenticate against endpoint")
 	DownloadFromFirehoseCmd.Flags().BoolP("plaintext", "p", false, "Use plaintext connection to firehose")
 	DownloadFromFirehoseCmd.Flags().BoolP("insecure", "k", false, "Skip SSL certificate validation when connecting to firehose")
-	DownloadFromFirehoseCmd.Flags().Bool("fix-ordinals", false, "Decode the eth blocks to fix the ordinals in the receipt logs")
+	DownloadFromFirehoseCmd.Flags().Uint32("block-version", 0, "Overwrite the block version. Use this if you want to indicate the blocks have been updated to a new version.")
 }
 
 var DownloadFromFirehoseCmd = &cobra.Command{
@@ -28,8 +28,10 @@ var DownloadFromFirehoseCmd = &cobra.Command{
 	Short:   "download blocks from firehose and save them to merged-blocks",
 	Args:    cobra.ExactArgs(4),
 	RunE:    downloadFromFirehoseE,
-	Example: "fireeth tools download-from-firehose api.streamingfast.io 1000 2000 ./outputdir",
+	Example: "fireantelope tools download-from-firehose eos.firehose.eosnation.io 1000 2000 ./outputdir",
 }
+
+var blockVersion = uint32(0)
 
 func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
@@ -48,16 +50,14 @@ func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
 	apiTokenEnvVar := mustGetString(cmd, "api-token-env-var")
 	apiToken := os.Getenv(apiTokenEnvVar)
 
+	val, err := cmd.Flags().GetUint32("block-version")
+	if err == nil {
+		blockVersion = val
+	}
+
 	plaintext := mustGetBool(cmd, "plaintext")
 	insecure := mustGetBool(cmd, "insecure")
 	var fixerFunc func(*bstream.Block) (*bstream.Block, error)
-	if mustGetBool(cmd, "fix-ordinals") {
-		fixerFunc = func(in *bstream.Block) (*bstream.Block, error) {
-			block := in.ToProtocol().(*pbeth.Block)
-			block.NormalizeInPlace()
-			return types.BlockFromProto(block, in.LibNum)
-		}
-	}
 
 	return sftools.DownloadFirehoseBlocks(
 		ctx,
@@ -68,20 +68,21 @@ func downloadFromFirehoseE(cmd *cobra.Command, args []string) error {
 		start,
 		stop,
 		destFolder,
-		decodeAnyPB,
+		decodeAndUpdateBlock,
 		fixerFunc,
 		zlog,
 	)
 }
 
-func decodeAnyPB(in *anypb.Any) (*bstream.Block, error) {
-	block := &pbeth.Block{}
+func decodeAndUpdateBlock(in *anypb.Any) (*bstream.Block, error) {
+	block := &pbantelope.Block{}
 	if err := anypb.UnmarshalTo(in, block, proto.UnmarshalOptions{}); err != nil {
 		return nil, fmt.Errorf("unmarshal anypb: %w", err)
 	}
 
-	// We are downloading only final blocks from the Firehose connection which means the LIB for them
-	// can be set to themself (althought we use `- 1` to ensure problem would occur if codde don't like
-	// `LIBNum == self.BlockNum`).
-	return types.BlockFromProto(block, block.Number-1)
+	if blockVersion > 0 {
+		block.Version = blockVersion
+	}
+
+	return types.BlockFromProto(block)
 }

--- a/types/block.go
+++ b/types/block.go
@@ -23,7 +23,7 @@ func BlockFromProto(b *pbantelope.Block) (*bstream.Block, error) {
 		Timestamp:      b.Time(),
 		LibNum:         b.LIBNum(),
 		PayloadKind:    pbbstream.Protocol_EOS,
-		PayloadVersion: 1,
+		PayloadVersion: int32(b.Version),
 	}
 
 	return bstream.GetBlockPayloadSetter(blk, content)


### PR DESCRIPTION
This ports over the firehose-block-downloader tool from the ethereum firehose and adds a flag to set the block version. This allows to download v2 blocks and update them to v3.